### PR TITLE
Allow replacing the expo bridge module's native Android code

### DIFF
--- a/plugin/src/android/withModule.ts
+++ b/plugin/src/android/withModule.ts
@@ -26,19 +26,17 @@ export const withModule: ConfigPlugin<WithExpoAndroidWidgetsProps> = (
             const packageNameAsPath = packageName?.replace(/\./g, "/");
             const moduleSourcePath = path.join(widgetFolderPath, 'src/main/java/package_name/ExpoWidgetsModule.kt');
             const moduleDestinationPath = path.join(
-                projectRoot, 
-                'android/src/main/java', 
-                packageNameAsPath, 
-                'Module.kt'
+                __dirname, 
+                '../../../android/src/main/java/expo/modules/widgets/ExpoWidgetsModule.kt'
             );
 
             if (!fs.existsSync(moduleSourcePath)) {
                 Logging.logger.debug('No module file found. Adding template...');
                 const contents = getTemplate(packageName);
-                // fs.writeFileSync(moduleDestinationPath, contents);
+                fs.writeFileSync(moduleDestinationPath, contents);
             }
             else {
-                // fs.writeFileSync()
+                fs.copyFileSync(moduleSourcePath, moduleDestinationPath);
             }
 
             return newConfig;


### PR DESCRIPTION
With iOS widgets, the `Module.swift` file would automatically become the `ExpoWidgetsModule.swift` file. That was not the case for a `Module.kt` file, but should be now. I followed the exact same format as is used in the iOS version.