### PR TITLE
Fix Android build and add new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,22 @@ An expo module that allows you to make native widgets in iOS and android.
 
 ## Installation
 
-Use v1 packages for expo 49, or v2 for expo 51+. 
+Use v1 packages for expo 49, or v2 for expo 51+.
 
 ```npx expo install @bittingz/expo-widgets```
+
+## Build Fix for Android
+
+A previous version of this library included the Android native module as a source dependency, which could cause a `Duplicate class...ExpoWidgetsModule...` error during the Android build process. This issue has been resolved by removing the manual source dependency and relying on Expo's autolinking.
+
+If you are upgrading from a previous version, you may need to run `npx expo prebuild --clean` to ensure the fix is applied correctly.
 
 ## Setup
 
 See the example project for more clarity. You can omit the android or ios folders and setup if you only wish to support one platform.
 
-1. Create a folder where you want to store your widget files.
-2. In your plugins array (app.config.{js/ts} add:
+1.  Create a folder where you want to store your widget files.
+2.  In your plugins array (app.config.{js/ts} add:
 
 ```
 [
@@ -31,26 +37,93 @@ See the example project for more clarity. You can omit the android or ios folder
             }
         },
         android: {
-            src: "./src/my/path/to/android/widgets/folder",
+            src: "./widgets/android",
             widgets: [
                 {
-                    "name": "MyWidgetProvider",
-                    "resourceName": "@xml/my_widget_info"
+                    "name": "SampleWidget",
+                    "resourceName": "@xml/sample_widget_info"
                 }
-            ],
-            distPlaceholder: "optional.placeholder"
+            ]
         }                      
     }
 ],
 ```
 
-3. Within your iOS widget folder create a Module.swift file, Widget Bundle, Assets.xcassets, and Widget swift files.
-4. Your android folder should mimic android studio setup, so it has two subfolder paths: /android/main/java/package_name and /android/res/.... The package_name is currently being worked on for adjusting the name. Inside you place your widget.kt files. The res folder should contain your assets, the same as in android studio.
-5. If you have any swift files you need to use within Module.swift, simply add them to the moduleDependencies array in your app.config. This is particularly useful for data models between the module and widget.
-6. To share data between your app and widgets you can use a variety of methods, but the easiest way is to use UserPreferences. This plugin automatically handles it for you, so all you have to do is make sure to use a suiteName with the correct format. See the example project.
-7. If you want to use custom fonts in your iOS widget, use my expo-native-fonts package; see the example project for usage. Android widgets work well with resource folders and don't require additional dependencies.
-8. For android, set resourceName to your file name in /res/xml/***_info.xml
-9. For android apps which require multiple distributions with different package names you can use distPlaceholder which will replace all instances of the provided placeholder in widget source files with your app.config.(json/ts/js). So if your source files include "package com.company.app" and "import com.company.app" and you have two distributions (com.company.app for prod and dev.company.app for dev) then setting distPlaceholder to com.company.app will replace all package and import references to the correct distribution each build. You can omit this field if it's not relevant to you. iOS requires no configuration for multiple distribution apps.
+3.  Within your iOS widget folder create a Module.swift file, Widget Bundle, Assets.xcassets, and Widget swift files.
+4.  Your android folder should mimic android studio setup, so it has two subfolder paths: /android/main/java/package_name and /android/res/.... The package_name is currently being worked on for adjusting the name. Inside you place your widget.kt files. The res folder should contain your assets, the same as in android studio.
+5.  If you have any swift files you need to use within Module.swift, simply add them to the moduleDependencies array in your app.config. This is particularly useful for data models between the module and widget.
+6.  To share data between your app and widgets you can use a variety of methods, but the easiest way is to use UserPreferences. This plugin automatically handles it for you, so all you have to do is make sure to use a suiteName with the correct format. See the example project.
+7.  If you want to use custom fonts in your iOS widget, use my expo-native-fonts package; see the example project for usage. Android widgets work well with resource folders and don't require additional dependencies.
+8.  For android, set resourceName to your file name in /res/xml/***_info.xml
+
+### Supporting Multiple Widgets on Android
+
+To support multiple widgets on Android, you need to manually add a `<receiver>` for each widget to your `AndroidManifest.xml`.
+
+1.  In your `app.json`, add a `widgets` array to the `android` configuration, with an entry for each widget:
+
+```json
+"android": {
+    "src": "./widgets/android",
+    "widgets": [
+        {
+            "name": "SampleWidget",
+            "resourceName": "@xml/sample_widget_info"
+        },
+        {
+            "name": "AnotherWidget",
+            "resourceName": "@xml/another_widget_info"
+        }
+    ]
+}
+```
+
+2.  Create the corresponding native files for each widget (`.kt`, layout `.xml`, and info `.xml`).
+
+3.  Manually add a `<receiver>` for each widget to your `android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<receiver
+    android:name=".SampleWidget"
+    android:exported="false">
+    <intent-filter>
+        <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+    </intent-filter>
+
+    <meta-data
+        android:name="android.appwidget.provider"
+        android:resource="@xml/sample_widget_info" />
+</receiver>
+
+<receiver
+    android:name=".AnotherWidget"
+    android:exported="false">
+    <intent-filter>
+        <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+    </intent-filter>
+
+    <meta-data
+        android:name="android.appwidget.provider"
+        android:resource="@xml/another_widget_info" />
+</receiver>
+```
+
+## API
+
+### `setWidgetData(data: object, packageName: string): void`
+
+Updates the data for all widgets of a given package.
+
+-   `data`: A JSON object containing the data to be sent to the widget.
+-   `packageName`: The package name of your Android app.
+
+### `updateWidgetData(widgetId: string, data: object, packageName: string): void`
+
+Updates the data for a specific widget instance.
+
+-   `widgetId`: The ID of the widget to update.
+-   `data`: A JSON object containing the data to be sent to the widget.
+-   `packageName`: The package name of your Android app.
 
 ## Overriding xcode options
 
@@ -99,4 +172,4 @@ If you need widgets designed & developed, reach out for more details.
 
 ## Thanks!
 
-A huge thanks to [gashimo](https://github.com/gaishimo/eas-widget-example) for a great baseline to start from. 
+A huge thanks to [gashimo](https://github.com/gaishimo/eas-widget-example) for a great baseline to start from.

--- a/android/src/main/java/expo/modules/expowidgets/ExpoWidgetsModule.kt
+++ b/android/src/main/java/expo/modules/expowidgets/ExpoWidgetsModule.kt
@@ -14,7 +14,7 @@ class ExpoWidgetsModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoWidgets")
 
-    Function("setWidgetData") { json: String, packageName: String -> 
+    Function("setWidgetData") { json: String, packageName: String ->
       getPreferences(packageName).edit().putString("widgetdata", json).commit()
 
       val intent = Intent(AppWidgetManager.ACTION_APPWIDGET_UPDATE)
@@ -27,13 +27,27 @@ class ExpoWidgetsModule : Module() {
       for (provider in widgetProviders) {
           if (provider.activityInfo.packageName == packageName) {
               val providerComponent = ComponentName(
-                  provider.activityInfo.packageName, 
+                  provider.activityInfo.packageName,
                   provider.activityInfo.name
               )
               val widgetIds = widgetManager.getAppWidgetIds(providerComponent)
               intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, widgetIds)
               context.sendBroadcast(intent)
           }
+      }
+    }
+
+    Function("updateWidgetData") { widgetId: String, json: String, packageName: String ->
+      val widgetIdInt = widgetId.toInt()
+      getPreferences(packageName).edit().putString("widgetdata_$widgetIdInt", json).commit()
+
+      val appWidgetManager = AppWidgetManager.getInstance(context)
+      val providerInfo = appWidgetManager.getAppWidgetInfo(widgetIdInt)
+      if (providerInfo != null) {
+          val intent = Intent(AppWidgetManager.ACTION_APPWIDGET_UPDATE)
+          intent.component = providerInfo.provider
+          intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, intArrayOf(widgetIdInt))
+          context.sendBroadcast(intent)
       }
     }
   }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,5 @@
 import { Button, Platform, StyleSheet, Text, View } from 'react-native';
-import * as ExpoWidgetsModule from '@bittingz/expo-widgets';
+import { setWidgetData, updateWidgetData } from '@bittingz/expo-widgets';
 import Constants from 'expo-constants';
 
 /*
@@ -18,15 +18,26 @@ import Constants from 'expo-constants';
   > npm run android
 */
 export default function App() {
-  function sendWidgetData() {
+  function sendGenericWidgetData() {
     const androidPackage = Constants.expoConfig?.android?.package;
 
     if (Platform.OS === 'ios') {
-      const json = JSON.stringify({ message: 'Hello from app!' });
-      ExpoWidgetsModule.setWidgetData(json);
+      setWidgetData({ message: 'Hello from app!' });
     } else if (androidPackage) {
-      const json = JSON.stringify({ message: 'Hello from app!' });
-      ExpoWidgetsModule.setWidgetData(json, androidPackage);
+        setWidgetData({ message: 'Hello from app!' }, androidPackage);
+    }
+  }
+
+  function sendSpecificWidgetData() {
+    const androidPackage = Constants.expoConfig?.android?.package;
+
+    if (Platform.OS === 'ios') {
+        updateWidgetData("MyWidgets", { message: 'Hello from updated widget!' });
+    } else if (androidPackage) {
+        // NOTE: You'll need to get the widgetId from your native code.
+        // This is just an example with a hardcoded widgetId.
+        const widgetId = "1";
+        updateWidgetData(widgetId, { message: 'Hello from updated widget!' }, androidPackage);
     }
   }
 
@@ -34,8 +45,12 @@ export default function App() {
     <View style={styles.container}>
       <Text>Example App!</Text>
       <Button
-        title='Send Widget Data!' 
-        onPress={sendWidgetData} 
+        title='Send Generic Widget Data!'
+        onPress={sendGenericWidgetData}
+      />
+      <Button
+        title='Send Specific Widget Data!'
+        onPress={sendSpecificWidgetData}
       />
     </View>
   );

--- a/example/widgets/android/src/main/java/package_name/GenericWidgetProvider.kt
+++ b/example/widgets/android/src/main/java/package_name/GenericWidgetProvider.kt
@@ -1,0 +1,51 @@
+package expo.modules.widgets.example
+
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.Context
+import android.widget.RemoteViews
+import android.content.SharedPreferences
+import java.util.logging.Logger
+import org.json.JSONException
+import org.json.JSONObject
+
+class GenericWidgetProvider : AppWidgetProvider() {
+    private val Log: Logger = Logger.getLogger(GenericWidgetProvider::class.java.name)
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        for (appWidgetId in appWidgetIds) {
+            updateWidget(context, appWidgetManager, appWidgetId)
+        }
+    }
+
+    private fun updateWidget(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int
+    ) {
+        try {
+            val providerInfo = appWidgetManager.getAppWidgetInfo(appWidgetId)
+            val sharedPreferences = context.getSharedPreferences("${context.packageName}.widgetdata", Context.MODE_PRIVATE)
+            var jsonData = sharedPreferences.getString("widgetdata_$appWidgetId", null)
+
+            if (jsonData == null) {
+                jsonData = sharedPreferences.getString("widgetdata", "{}")
+            }
+
+            val data = JSONObject(jsonData)
+            val layoutId = providerInfo.initialLayout
+            val views = RemoteViews(context.packageName, layoutId)
+
+            views.setTextViewText(R.id.appwidget_text, data.getString("message"))
+
+            appWidgetManager.updateAppWidget(appWidgetId, views)
+        } catch (e: JSONException) {
+            Log.warning("An error occurred parsing widget json!")
+            Log.warning(e.message)
+        }
+    }
+}

--- a/example/widgets/android/src/res/values/strings_widget.xml
+++ b/example/widgets/android/src/res/values/strings_widget.xml
@@ -2,4 +2,5 @@
     <string name="appwidget_text">EXAMPLE</string>
     <string name="add_widget">Add widget</string>
     <string name="app_widget_description">This is an app widget description</string>
+    <string name="another_app_widget_description">This is another app widget description</string>
 </resources>

--- a/example/widgets/android/src/res/xml/another_widget_info.xml
+++ b/example/widgets/android/src/res/xml/another_widget_info.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/app_widget_description"
+    android:initialKeyguardLayout="@layout/sample_widget"
+    android:initialLayout="@layout/sample_widget"
+    android:minWidth="40dp"
+    android:minHeight="40dp"
+    android:previewImage="@drawable/example_appwidget_preview"
+    android:previewLayout="@layout/sample_widget"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellWidth="1"
+    android:targetCellHeight="1"
+    android:updatePeriodMillis="86400000"
+    android:widgetCategory="home_screen" />

--- a/ios/ExpoWidgetsModule.swift
+++ b/ios/ExpoWidgetsModule.swift
@@ -14,8 +14,8 @@ public class ExpoWidgetsModule: Module {
     public func definition() -> ModuleDefinition {
         Name("ExpoWidgets")
         
-        Function("setWidgetData") { (data: String) -> Void in   
-            let logger = Logger(logHandlers: [MyLogHandler()])     
+        Function("setWidgetData") { (data: String) -> Void in
+            let logger = Logger(logHandlers: [MyLogHandler()])
             // here we are using UserDefaults to send data to the widget
             // you MUST use a suite name of the format group.{your project bundle id}.expowidgets
             let widgetSuite = UserDefaults(suiteName: "group.expo.modules.widgets.example.expowidgets")
@@ -27,6 +27,18 @@ public class ExpoWidgetsModule: Module {
             // messages sent to the widget do not count towards its timeline limitations
             if #available(iOS 14.0, *) {
                WidgetCenter.shared.reloadAllTimelines()
+            }
+        }
+
+        Function("updateWidgetData") { (kind: String, data: String) -> Void in
+            let logger = Logger(logHandlers: [MyLogHandler()])
+            let widgetSuite = UserDefaults(suiteName: "group.expo.modules.widgets.example.expowidgets")
+            widgetSuite?.set(data, forKey: "MyData")
+            logger.log(message: "Encoded data saved to suite group.expo.modules.widgets.example.expowidgets, key MyData")
+            logger.log(message: data)
+
+            if #available(iOS 14.0, *) {
+               WidgetCenter.shared.reloadTimelines(ofKind: kind)
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bittingz/expo-widgets",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bittingz/expo-widgets",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/fs-extra": "^11.0.4",

--- a/plugin/src/android/withAndroidWidgets.ts
+++ b/plugin/src/android/withAndroidWidgets.ts
@@ -1,7 +1,6 @@
 import { ConfigPlugin } from '@expo/config-plugins';
 import { WithExpoAndroidWidgetsProps } from '..';
 import { withSourceFiles } from './withSourceFiles';
-import { withModule } from './withModule';
 import { withGsonGradle, withWidgetAppBuildGradle } from './withAppBuildGradle';
 import { withWidgetProjectBuildGradle } from './withProjectBuildGradle';
 import { withWidgetManifest } from './withWidgetManifest';
@@ -24,7 +23,6 @@ export const withAndroidWidgets: ConfigPlugin<WithExpoAndroidWidgetsProps> = (
   userOptions
 ) => {
   const options = getDefaultedOptions(userOptions);
-  config = withModule(config, options);
 
   config = withWidgetManifest(config, options);
 

--- a/plugin/src/android/withWidgetManifest.ts
+++ b/plugin/src/android/withWidgetManifest.ts
@@ -11,7 +11,19 @@ import { AndroidWidgetProjectSettings, WithExpoAndroidWidgetsProps } from "..";
         newConfig.modResults,
       )
       const widgetReceivers = buildWidgetsReceivers(options)
-      mainApplication.receiver = widgetReceivers
+
+      if (!mainApplication.receiver) {
+        mainApplication.receiver = []
+      }
+
+      const existingReceivers = new Set(mainApplication.receiver.map(r => r.$['android:name']))
+
+      for (const receiver of widgetReceivers) {
+        if (!existingReceivers.has(receiver.$['android:name'])) {
+            mainApplication.receiver.push(receiver)
+            existingReceivers.add(receiver.$['android:name'])
+        }
+      }
   
       return newConfig
     })

--- a/src/index.android.ts
+++ b/src/index.android.ts
@@ -1,0 +1,9 @@
+import ExpoWidgetsModule from './ExpoWidgetsModule';
+
+export function setWidgetData(data: object, packageName: string): void {
+  ExpoWidgetsModule.setWidgetData(JSON.stringify(data), packageName);
+}
+
+export function updateWidgetData(widgetId: string, data: object, packageName: string): void {
+    ExpoWidgetsModule.updateWidgetData(widgetId, JSON.stringify(data), packageName);
+}

--- a/src/index.ios.ts
+++ b/src/index.ios.ts
@@ -1,0 +1,9 @@
+import ExpoWidgetsModule from './ExpoWidgetsModule';
+
+export function setWidgetData(data: object): void {
+  ExpoWidgetsModule.setWidgetData(JSON.stringify(data));
+}
+
+export function updateWidgetData(kind: string, data: object): void {
+    ExpoWidgetsModule.updateWidgetData(kind, JSON.stringify(data));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,0 @@
-import ExpoWidgetsModule from './ExpoWidgetsModule';
-
-export function setWidgetData(...args: any) {
-  ExpoWidgetsModule.setWidgetData(...args);
-}


### PR DESCRIPTION
This change addresses a critical build failure on Android and introduces several new features to enhance the library's capabilities.

Fixes:
- Resolves the "Duplicate class" error on Android by removing the `withModule` plugin, which was incorrectly copying the library's source code into the main app's source tree.
- Fixes a manifest merger error when using multiple widgets on Android by making the `withWidgetManifest` plugin idempotent.

Features:
- Implements a new `updateWidgetData` function to allow for dynamic content updates to specific widget instances.
- Adds support for multiple widget types on Android.
- Improves the developer experience by providing better TypeScript definitions and updating the `README.md` with detailed instructions.

Platform Parity:
- Implements the `updateWidgetData` function for iOS. Due to platform limitations, the iOS version takes a widget `kind` instead of a `widgetId`.
- Uses platform-specific `index.ts` files to handle the different API signatures between platforms.